### PR TITLE
Feat/restart nonce better

### DIFF
--- a/sto/cli/main.py
+++ b/sto/cli/main.py
@@ -445,8 +445,11 @@ def last(config: BoardCommmadConfiguration, limit):
 
 
 @cli.command(name="tx-restart-nonce")
+@click.option('--reset-pending-tx', required=False, help="Delete's any pending tx", type=bool, default=None)
 @click.pass_obj
-def restart_nonce(config: BoardCommmadConfiguration):
+def restart_nonce(config: BoardCommmadConfiguration, reset_pending_tx):
+
+
     """Resets the broadcasting account nonce."""
 
     assert is_ethereum_network(config.network)
@@ -463,7 +466,8 @@ def restart_nonce(config: BoardCommmadConfiguration):
           ethereum_node_url=config.ethereum_node_url,
           ethereum_private_key=config.ethereum_private_key,
           ethereum_gas_limit=config.ethereum_gas_limit,
-          ethereum_gas_price=config.ethereum_gas_price)
+          ethereum_gas_price=config.ethereum_gas_price,
+          reset_pending_tx=reset_pending_tx)
 
 @cli.command(name="tx-next-nonce")
 @click.pass_obj

--- a/sto/ethereum/nonce.py
+++ b/sto/ethereum/nonce.py
@@ -25,7 +25,10 @@ def restart_nonce(logger: Logger,
               ethereum_private_key: str,
               ethereum_gas_limit: str,
               ethereum_gas_price: str,
+              reset_pending_tx: bool,
+
 ):
+
     check_good_private_key(ethereum_private_key)
 
     web3 = create_web3(ethereum_node_url)
@@ -36,8 +39,9 @@ def restart_nonce(logger: Logger,
 
     account = service.get_or_create_broadcast_account()
     txs = service.get_last_transactions(limit=1)
-    if txs.count() > 0:
-        raise HistoryDeleteNeeded("Cannot reset nonce as the database contains txs for {}. Delete database to restart.".format(service.address))
+    if txs.count() > 0 and reset_pending_tx = True:
+        service.delete_pending_broadcasts()
+
 
     # read nonce from the network and record to the database
     tx_count = web3.eth.getTransactionCount(service.address)

--- a/sto/ethereum/txservice.py
+++ b/sto/ethereum/txservice.py
@@ -335,7 +335,7 @@ class EthereumStoredTXService:
     def get_last_transactions(self, limit: int) -> Query:
         """Fetch latest transactions."""
         assert type(limit) == int
-        return self.dbsession.query(self.prepared_tx_model).order_by(restart-nonce.prepared_tx_model.created_at.desc()).limit(limit)
+        return self.dbsession.query(self.prepared_tx_model).order_by(self.prepared_tx_model.created_at.desc()).limit(limit)
 
     def broadcast(self, tx: _PreparedTransaction):
         """Push transactions to Ethereum network."""


### PR DESCRIPTION
If there are transactions in the queue and they have a nonce assigned and it does not match to the network nonce, then we need to discard these transactions